### PR TITLE
AGP-137 Fix webpack occupied port error

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -58,7 +58,6 @@ module.exports = {
   ],
   devServer: {
     contentBase: './public',
-    port: 3000,
     hot: true,
     open: true
   },


### PR DESCRIPTION
- Removed `port` option in webpack config. This allows webpack to search for free ports after the default port (8080).

Not a necessary change.